### PR TITLE
feat!: support fastify v4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         if: github.event.pull_request.draft == false
         strategy:
             matrix:
-                node-version: [12, 14, 16, 18]
+                node-version: [14, 16, 18]
                 os: [macos-latest, ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Or [`yarn`](https://yarnpkg.com/en/package/fastify-floc-off):
 yarn add fastify-floc-off
 ```
 
+For Fastify v3.x support, use `fastify-floc-off@1.0.7`.
+
 fastify-floc-off's test scripts use npm commands.
 
 ## Example Usage

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	"license": "MIT",
 	"author": "Frazer Smith <frazer.dev@outlook.com>",
 	"engines": {
-		"node": ">=12.0.0"
+		"node": ">=14.0.0"
 	},
 	"scripts": {
 		"jest": "jest",
@@ -51,22 +51,22 @@
 	"devDependencies": {
 		"@commitlint/cli": "^17.0.1",
 		"@commitlint/config-conventional": "^17.0.0",
-		"eslint": "^8.9.0",
+		"eslint": "^8.16.0",
 		"eslint-config-airbnb-base": "^15.0.0",
-		"eslint-config-prettier": "^8.4.0",
-		"eslint-plugin-import": "^2.25.4",
-		"eslint-plugin-jest": "^26.1.1",
-		"eslint-plugin-jsdoc": "^39.2.9",
+		"eslint-config-prettier": "^8.5.0",
+		"eslint-plugin-import": "^2.26.0",
+		"eslint-plugin-jest": "^26.2.2",
+		"eslint-plugin-jsdoc": "^39.3.1",
 		"eslint-plugin-promise": "^6.0.0",
-		"eslint-plugin-security": "^1.4.0",
+		"eslint-plugin-security": "^1.5.0",
 		"eslint-plugin-security-node": "^1.1.1",
-		"fastify": "^3.27.2",
+		"fastify": "^4.0.0-rc.3",
 		"husky": "^8.0.1",
-		"jest": "^28.0.3",
+		"jest": "^28.1.0",
 		"license-checker": "^25.0.1",
-		"prettier": "^2.5.1"
+		"prettier": "^2.6.2"
 	},
 	"dependencies": {
-		"fastify-plugin": "^3.0.0"
+		"fastify-plugin": "^3.0.1"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,4 +11,4 @@ async function plugin(server) {
 	});
 }
 
-module.exports = fp(plugin, { fastify: "3.x", name: "fastify-floc-off" });
+module.exports = fp(plugin, { fastify: "4.x", name: "fastify-floc-off" });


### PR DESCRIPTION
BREAKING CHANGE: dropped support for node 12 and fastify v3.x