### PR TITLE
perf(index)!: switch to callback style to remove Promise overhead

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,12 @@ const DIRECTIVE = "interest-cohort=()";
  * @description Simple plugin that adds an `onRequest` hook to opt out of Google's FLoC
  * advertising-surveillance network by setting/adding the "interest-cohort=()" directive
  * to the Permissions-Policy response header.
- * @param {import("fastify").FastifyInstance} server - Fastify instance.
+ * @type {import("fastify").FastifyPluginCallback}
  */
-async function fastifyFlocOff(server) {
+function fastifyFlocOff(server, _opts, done) {
 	server.addHook(
 		"onRequest",
-		async function setFlocPermissionsHeader(_req, res) {
+		function setFlocPermissionsHeader(_req, res, next) {
 			const header = res.getHeader("Permissions-Policy");
 
 			if (Array.isArray(header)) {
@@ -30,8 +30,10 @@ async function fastifyFlocOff(server) {
 				// No header exists yet
 				res.header("Permissions-Policy", DIRECTIVE);
 			}
+			next();
 		}
 	);
+	done();
 }
 
 module.exports = fp(fastifyFlocOff, {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,11 @@
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginCallback } from "fastify";
 
 declare namespace fastifyFlocOff {
-	export const fastifyFlocOff: FastifyPluginAsync;
+	export const fastifyFlocOff: FastifyPluginCallback;
 	export { fastifyFlocOff as default };
 }
 
 declare function fastifyFlocOff(
-	...params: Parameters<FastifyPluginAsync>
-): ReturnType<FastifyPluginAsync>;
+	...params: Parameters<FastifyPluginCallback>
+): ReturnType<FastifyPluginCallback>;
 export = fastifyFlocOff;


### PR DESCRIPTION
BREAKING CHANGE: Plugin types changed from `FastifyPluginAsync` to `FastifyPluginCallback`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
