### PR TITLE
perf(index): hoist `setFlocPermissionsHeader` to module scope

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,33 +6,38 @@ const DIRECTIVE = "interest-cohort=()";
 
 /**
  * @author Frazer Smith
+ * @description Sets/adds the "interest-cohort=()" directive to the
+ * Permissions-Policy response header.
+ * @type {import("fastify").onRequestHookHandler}
+ */
+function setFlocPermissionsHeader(_req, res, next) {
+	const header = res.getHeader("Permissions-Policy");
+
+	if (Array.isArray(header)) {
+		if (!header.some((item) => item.includes(DIRECTIVE))) {
+			header.push(DIRECTIVE);
+			res.header("Permissions-Policy", header);
+		}
+	} else if (typeof header === "string") {
+		if (!header.includes(DIRECTIVE)) {
+			res.header("Permissions-Policy", `${header}, ${DIRECTIVE}`);
+		}
+	} else {
+		// No header exists yet
+		res.header("Permissions-Policy", DIRECTIVE);
+	}
+	next();
+}
+
+/**
+ * @author Frazer Smith
  * @description Simple plugin that adds an `onRequest` hook to opt out of Google's FLoC
  * advertising-surveillance network by setting/adding the "interest-cohort=()" directive
  * to the Permissions-Policy response header.
  * @type {import("fastify").FastifyPluginCallback}
  */
 function fastifyFlocOff(server, _options, done) {
-	server.addHook(
-		"onRequest",
-		function setFlocPermissionsHeader(_req, res, next) {
-			const header = res.getHeader("Permissions-Policy");
-
-			if (Array.isArray(header)) {
-				if (!header.some((item) => item.includes(DIRECTIVE))) {
-					header.push(DIRECTIVE);
-					res.header("Permissions-Policy", header);
-				}
-			} else if (typeof header === "string") {
-				if (!header.includes(DIRECTIVE)) {
-					res.header("Permissions-Policy", `${header}, ${DIRECTIVE}`);
-				}
-			} else {
-				// No header exists yet
-				res.header("Permissions-Policy", DIRECTIVE);
-			}
-			next();
-		}
-	);
+	server.addHook("onRequest", setFlocPermissionsHeader);
 	done();
 }
 


### PR DESCRIPTION
Moved the onRequest handler out of fastifyFlocOff so it’s defined once at module load, reducing setup allocations when the plugin is registered multiple times.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
