### PR TITLE
perf(index): use imperative over func loop to avoid closure overhead

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,16 +12,23 @@ const DIRECTIVE = "interest-cohort=()";
  * @type {import("fastify").onRequestHookHandler}
  */
 function setFlocPermissionsHeader(_req, res, done) {
-	const header = res.getHeader(HEADER);
+	const existing = res.getHeader(HEADER);
 
-	if (Array.isArray(header)) {
-		if (!header.some((item) => item.includes(DIRECTIVE))) {
-			header.push(DIRECTIVE);
-			res.header(HEADER, header);
+	if (Array.isArray(existing)) {
+		let found = false;
+		for (let i = 0; i < existing.length; i += 1) {
+			if (existing[i].includes(DIRECTIVE)) {
+				found = true;
+				break;
+			}
 		}
-	} else if (typeof header === "string") {
-		if (!header.includes(DIRECTIVE)) {
-			res.header(HEADER, `${header}, ${DIRECTIVE}`);
+		if (!found) {
+			existing.push(DIRECTIVE);
+			res.header(HEADER, existing);
+		}
+	} else if (typeof existing === "string") {
+		if (!existing.includes(DIRECTIVE)) {
+			res.header(HEADER, `${existing}, ${DIRECTIVE}`);
 		}
 	} else {
 		// No header exists yet

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ function setFlocPermissionsHeader(_req, res, done) {
 
 	if (Array.isArray(existing)) {
 		let found = false;
-		for (let i = 0; i < existing.length; i += 1) {
+		const existingLength = existing.length;
+		for (let i = 0; i < existingLength; i += 1) {
 			if (existing[i].includes(DIRECTIVE)) {
 				found = true;
 				break;


### PR DESCRIPTION
Shaves off a few nano-seconds from benchmarking.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
