### PR TITLE
chore(.vscode): remove redundant javascript default formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,9 +4,6 @@
 	"eslint.useFlatConfig": true,
 	"files.eol": "\n",
 	"gitlens.telemetry.enabled": false,
-	"[javascript]": {
-		"editor.defaultFormatter": "esbenp.prettier-vscode"
-	},
 	"js/ts.updateImportsOnFileMove.enabled": "always",
 	"npm.packageManager": "npm",
 	"prettier.prettierPath": "./node_modules/prettier/index.cjs",


### PR DESCRIPTION
Removed JavaScript default formatter setting. Not needed as it's not different from the standard default

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
