### PR TITLE
perf(index): avoid `toLowerCase()` allocations every request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const HEADER = "permissions-policy";
 const DIRECTIVE = "interest-cohort=()";
 // Cache immutable regex as they are expensive to create and garbage collect
 // Use case-insensitive match without allocating new strings like `String.toLowerCase()` would do
-const DIRECTIVE_REG = /interest-cohort=\(\)/i;
+const DIRECTIVE_REG = /interest-cohort=\(\)/iu;
 
 /**
  * @author Frazer Smith

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,9 @@ const fp = require("fastify-plugin");
 
 const HEADER = "permissions-policy";
 const DIRECTIVE = "interest-cohort=()";
+// Cache immutable regex as they are expensive to create and garbage collect
+// Use case-insensitive match without allocating new strings like `String.toLowerCase()` would do
+const DIRECTIVE_REG = /interest-cohort=\(\)/i;
 
 /**
  * @author Frazer Smith
@@ -18,7 +21,7 @@ function setFlocPermissionsHeader(_req, res, done) {
 		let found = false;
 		const existingLength = existing.length;
 		for (let i = 0; i < existingLength; i += 1) {
-			if (existing[i].toLowerCase().includes(DIRECTIVE)) {
+			if (DIRECTIVE_REG.test(existing[i])) {
 				found = true;
 				break;
 			}
@@ -28,7 +31,7 @@ function setFlocPermissionsHeader(_req, res, done) {
 			res.header(HEADER, existing);
 		}
 	} else if (typeof existing === "string") {
-		if (!existing.toLowerCase().includes(DIRECTIVE)) {
+		if (!DIRECTIVE_REG.test(existing)) {
 			res.header(HEADER, `${existing}, ${DIRECTIVE}`);
 		}
 	} else {


### PR DESCRIPTION
`String.prototype.toLowerCase()` allocates a new string for every header value on every request, adding pressure to the garbage collector.

Benchmark comparison:

Node 20.20.2:
tolower mean=91.72ms median=91.49ms p95=96.03ms ops/s=54,514,500 gc=0.00ms
regex mean=71.63ms median=72.46ms p95=72.92ms ops/s=69,805,356 gc=0.00ms
faster: regex (21.90% by mean)

Node 24.18.0:
tolower  mean=78.14ms median=78.10ms p95=79.86ms ops/s=63,983,955 gc=0.00ms
regex    mean=73.72ms median=73.46ms p95=81.55ms ops/s=67,828,562 gc=0.00ms
faster: regex (5.67% by mean)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
