### PR TITLE
ci(cd): pin installed npm version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,7 +58,7 @@ jobs:
               # Build docs/definitions, and remove dev values
               # from package.json before publishing to reduce package size
               run: |
-                  npm i -g npm@11.18.0 --ignore-scripts
+                  npm i -g npm@11 --ignore-scripts
                   npm i --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies scripts
@@ -104,7 +104,7 @@ jobs:
               # Build docs/definitions, and remove dev values
               # from package.json before publishing to reduce package size
               run: |
-                  npm i -g npm@11.18.0 --ignore-scripts
+                  npm i -g npm@11 --ignore-scripts
                   npm i --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies scripts

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,7 +58,7 @@ jobs:
               # Build docs/definitions, and remove dev values
               # from package.json before publishing to reduce package size
               run: |
-                  npm i -g npm@latest
+                  npm i -g npm@11.18.0 --ignore-scripts
                   npm i --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies scripts
@@ -104,7 +104,7 @@ jobs:
               # Build docs/definitions, and remove dev values
               # from package.json before publishing to reduce package size
               run: |
-                  npm i -g npm@latest
+                  npm i -g npm@11.18.0 --ignore-scripts
                   npm i --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies scripts

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,7 +58,7 @@ jobs:
               # Build docs/definitions, and remove dev values
               # from package.json before publishing to reduce package size
               run: |
-                  npm i -g npm@11 --ignore-scripts
+                  npm i -g npm@11.18.0 --ignore-scripts
                   npm i --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies scripts
@@ -104,7 +104,7 @@ jobs:
               # Build docs/definitions, and remove dev values
               # from package.json before publishing to reduce package size
               run: |
-                  npm i -g npm@11 --ignore-scripts
+                  npm i -g npm@11.18.0 --ignore-scripts
                   npm i --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies scripts


### PR DESCRIPTION
'latest' is v12 which dropped support for node 20, which this package is still supporting for time being. [Need v11 for OIDC publishing](https://docs.npmjs.com/trusted-publishers).